### PR TITLE
Move react to peerDependencies, and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
         "react-component"
     ],
     "dependencies"   : {
-        "react"           : "0.13",
-        "socket.io-client": "1.3"
+        "socket.io-client": "^1.4"
+    },
+    "peerDependencies"   : {
+        "react"           : "^0.13 || ^0.14 || ^15.0.0"
     },
     "devDependencies": {
         "proxyquire": "1.5",


### PR DESCRIPTION
making react be a peer dependency stops it from having its own local version of react which removes many warnings shown in the browser, and fixes support for react 15
